### PR TITLE
:technologist: Add single major versions of gcc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,12 @@ jobs:
       version: "12.3"
     secrets: inherit
 
+  deploy_12:
+    uses: ./.github/workflows/package_and_upload.yml
+    with:
+      version: "12"
+    secrets: inherit
+
   deploy_13_2:
     uses: ./.github/workflows/package_and_upload.yml
     with:
@@ -41,8 +47,20 @@ jobs:
       version: "13.3"
     secrets: inherit
 
+  deploy_13:
+    uses: ./.github/workflows/package_and_upload.yml
+    with:
+      version: "13"
+    secrets: inherit
+
   deploy_14_2:
     uses: ./.github/workflows/package_and_upload.yml
     with:
       version: "14.2"
+    secrets: inherit
+
+  deploy_14:
+    uses: ./.github/workflows/package_and_upload.yml
+    with:
+      version: "14"
     secrets: inherit

--- a/.github/workflows/package_and_upload.yml
+++ b/.github/workflows/package_and_upload.yml
@@ -33,7 +33,7 @@ jobs:
         run: conan hal setup
 
       - name: 📦 Create Conan Package
-        run: conan create prebuilt --version=${{ inputs.version }}
+        run: conan create prebuilt --version=${{ inputs.version }} -s compiler=gcc -s compiler.version=${{ inputs.version }}
 
       - name: 🏗️ Build Demos Conan Package
         working-directory: prebuilt/demo

--- a/.github/workflows/package_and_upload.yml
+++ b/.github/workflows/package_and_upload.yml
@@ -24,20 +24,13 @@ jobs:
           fetch-depth: 0
 
       - name: 📥 Install Conan
-        run: pipx install conan==2.16.1
+        run: pipx install conan>=2.16.1
 
-      - name: 📡 Add `libhal-trunk` conan remote
-        run: |
-          conan remote add libhal-trunk https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
+      - name: 📡 Install libhal conan config2
+        run: conan config install https://github.com/libhal/conan-config2.git
 
-      - name: 📡 Create and setup default profile
-        run: conan profile detect --force
-
-      - name: 👁️‍🗨️ Show conan profile
-        run: conan profile show
-
-      - name: 📡 Install libhal settings_user.yml
-        run: conan config install -sf profiles/baremetal/v2/ https://github.com/libhal/conan-config.git
+      - name: 📡 libhal setup
+        run: conan hal setup
 
       - name: 📦 Create Conan Package
         run: conan create prebuilt --version=${{ inputs.version }}
@@ -56,4 +49,4 @@ jobs:
       - name: 🆙 Upload `prebuilt-picolibc` to `libhal-trunk` repo
         if: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(matrix.os, 'ubuntu-') }}
         run: |
-          conan upload "prebuilt-picolibc/*" --only-recipe --confirm -r=libhal-trunk
+          conan upload "prebuilt-picolibc/*" --only-recipe --confirm -r=libhal

--- a/prebuilt/conandata.yml
+++ b/prebuilt/conandata.yml
@@ -8,12 +8,21 @@ sources:
   "12.3":
     url: "https://github.com/picolibc/picolibc/releases/download/1.8.3/picolibc-1.8.3-12.3-rel1.zip"
     sha256: "9263e6e7317b0e205e68a88301bde2b42fb758aa50df68251c17de2c493875f6"
+  "12":
+    url: "https://github.com/picolibc/picolibc/releases/download/1.8.3/picolibc-1.8.3-12.3-rel1.zip"
+    sha256: "9263e6e7317b0e205e68a88301bde2b42fb758aa50df68251c17de2c493875f6"
   "13.2":
     url: "https://github.com/picolibc/picolibc/releases/download/1.8.6/picolibc-1.8.6-13.2.Rel1.zip"
     sha256: "9658c58307000de6d9998b29904b1316196eadc4b31a7fe8f9bdefa0c8325bb6"
   "13.3":
     url: "https://github.com/picolibc/picolibc/releases/download/1.8.8/picolibc-1.8.8-13.3.rel1.zip"
     sha256: "a298cabc310e992399824ae48e275f49603ba1c5f3c040acb116e54146b70995"
+  "13":
+    url: "https://github.com/picolibc/picolibc/releases/download/1.8.8/picolibc-1.8.8-13.3.rel1.zip"
+    sha256: "a298cabc310e992399824ae48e275f49603ba1c5f3c040acb116e54146b70995"
   "14.2":
+    url: "https://github.com/picolibc/picolibc/releases/download/1.8.10/picolibc-1.8.10-14.2.rel1.zip"
+    sha256: "a5d0e5be0cd5e7b0e47a229a49f58d9b258a7012c3402751711d71415a645f99"
+  "14":
     url: "https://github.com/picolibc/picolibc/releases/download/1.8.10/picolibc-1.8.10-14.2.rel1.zip"
     sha256: "a5d0e5be0cd5e7b0e47a229a49f58d9b258a7012c3402751711d71415a645f99"

--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -1,11 +1,12 @@
 from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
 from conan.tools.files import get
 from pathlib import Path
 
 required_conan_version = ">=2.0.6"
 
 
-class PrebuiltPicolibc(ConanFile):
+class PrebuiltGccPicolibc(ConanFile):
     name = "prebuilt-picolibc"
     settings = "os", "arch", "compiler", "build_type"
     package_type = "static-library"
@@ -20,6 +21,11 @@ class PrebuiltPicolibc(ConanFile):
     default_options = {
         "crt0": "semihost",
     }
+
+    def validate(self):
+        if self.settings.compiler != "gcc":
+            raise ConanInvalidConfiguration(
+                "This package only works with GCC compiler")
 
     def package_id(self):
         self.info.clear()
@@ -43,10 +49,14 @@ class PrebuiltPicolibc(ConanFile):
             "11.3": "11.3.1",
             "12.2": "12.2.1",
             "12.3": "12.3.1",
+            "12":   "12.3.1",
             "13.2": "13.2.1",
             "13.3": "13.3.1",
+            "13": "13.3.1",
             "14.2": "14.2.1",
+            "14":   "14.2.1",
         }
+
         LONG_VERSION = SHORT_TO_LONG_VERSION[self.version]
         PREFIX = Path(self.package_folder) / 'arm-none-eabi'
         PICOLIB_CPP_SPECS = Path(self.package_folder) / 'lib' / 'gcc' / \


### PR DESCRIPTION
This way, a compiler setting of just 12, 13, or 14 will resolve to the latest version of picolibc for that version of GCC.