### PR TITLE
fix oslib flag to be gnu style

### DIFF
--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -65,7 +65,7 @@ class PrebuiltGccPicolibc(ConanFile):
         self.cpp_info.exelinkflags = [
             f"-specs={PICOLIB_CPP_SPECS}",
             f"--picolibc-prefix={PREFIX}",
-            f"-oslib={str(self.options.crt0)}",
+            f"--oslib={str(self.options.crt0)}",
         ]
 
         self.output.info(f"link flags: {self.cpp_info.exelinkflags}")


### PR DESCRIPTION
With only one dash, `-oslib=crtfile` is parsed as "output binary to file `slib=crtfile`". This is almost certainly the incorrect behavior, and causes oslib to not be set at all. Adding one dash makes this correct.