### PR TITLE
add oslib option, fix crt0 flag

### DIFF
--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -12,14 +12,21 @@ class PrebuiltGccPicolibc(ConanFile):
     package_type = "static-library"
     build_policy = "missing"
     options = {
+        "oslib": [
+            None,
+            "semihost",
+        ],
         "crt0": [
+            "default",
+            "none",
             "semihost",
             "hosted",
             "minimal",
         ]
     }
     default_options = {
-        "crt0": "semihost",
+        "oslib": None,
+        "crt0": "default",
     }
 
     def validate(self):
@@ -62,11 +69,17 @@ class PrebuiltGccPicolibc(ConanFile):
         PICOLIB_CPP_SPECS = Path(self.package_folder) / 'lib' / 'gcc' / \
             'arm-none-eabi' / LONG_VERSION / 'picolibcpp.specs'
 
-        self.cpp_info.exelinkflags = [
+        flags = [
             f"-specs={PICOLIB_CPP_SPECS}",
             f"--picolibc-prefix={PREFIX}",
-            f"--oslib={str(self.options.crt0)}",
+            f"--oslib={str(self.options.oslib)}",
         ]
+        if not self.options.crt0 == "default":
+            flags += f"--crt0={str(self.options.crt0)}"
+
+        self.cpp_info.exelinkflags = flags
+        self.cpp_info.cppflags = flags
+        self.cpp_info.cflags = flags
 
         self.output.info(f"link flags: {self.cpp_info.exelinkflags}")
         self.output.info(f"crt0: {str(self.options.crt0)}")

--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -74,10 +74,10 @@ class PrebuiltGccPicolibc(ConanFile):
             f"--picolibc-prefix={PREFIX}",
          
         ]
-        if self.options.oslib is not None:
-            flags += f"--oslib={str(self.options.oslib)}"
+        if self.options.oslib.value is not None:
+            flags += [f"--oslib={str(self.options.oslib)}"]
         if not self.options.crt0 == "default":
-            flags += f"--crt0={str(self.options.crt0)}"
+            flags += [f"--crt0={str(self.options.crt0)}"]
 
         self.cpp_info.exelinkflags = flags
         self.cpp_info.cppflags = flags

--- a/prebuilt/conanfile.py
+++ b/prebuilt/conanfile.py
@@ -72,8 +72,10 @@ class PrebuiltGccPicolibc(ConanFile):
         flags = [
             f"-specs={PICOLIB_CPP_SPECS}",
             f"--picolibc-prefix={PREFIX}",
-            f"--oslib={str(self.options.oslib)}",
+         
         ]
+        if self.options.oslib is not None:
+            flags += f"--oslib={str(self.options.oslib)}"
         if not self.options.crt0 == "default":
             flags += f"--crt0={str(self.options.crt0)}"
 


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Picolibc-Options.html

This fixes a latent build error that appears on environments that try building with a "hosted" crt0. The crt0 flag was conflated with the oslib flag, which resulted in an attempt to link to a non-existant hosted oslib. We provide a proper option for oslib, as well as adding the "none" and default option.

This also "changes" the default crt0 flag, but given that the flag was never correctly applied anyways, it would be more stable to reflect the default linkage to the default crt0 instead of the "semihosted" crt0. The default option for crt0 was named "default" instead of being `None`  to avoid confusion with the "none" option.